### PR TITLE
Fix code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/vendor/tightenco/ziggy/src/js/Router.js
+++ b/vendor/tightenco/ziggy/src/js/Router.js
@@ -119,7 +119,7 @@ export default class Router extends String {
 
         // Test the passed name against the current route, matching some
         // basic wildcards, e.g. passing `events.*` matches `events.show`
-        const match = new RegExp(`^${name.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`).test(
+        const match = new RegExp(`^${name.replace(/\\/g, '\\\\').replace(/\./g, '\\.').replace(/\*/g, '.*')}$`).test(
             current,
         );
 


### PR DESCRIPTION
Fixes [https://github.com/HidayatLahabu/SimgosAppData/security/code-scanning/8](https://github.com/HidayatLahabu/SimgosAppData/security/code-scanning/8)

To fix the problem, we need to ensure that backslashes in the `name` parameter are properly escaped before constructing the regular expression. This can be achieved by adding an additional `replace` call to escape backslashes. Specifically, we should replace each backslash (`\`) with a double backslash (`\\`) before performing the existing replacements for dots (`.`) and asterisks (`*`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
